### PR TITLE
fix: update documentation and descriptions to remove "CLI" references for Qwen Code integration

### DIFF
--- a/.github/commands/qwen-review.toml
+++ b/.github/commands/qwen-review.toml
@@ -1,4 +1,4 @@
-description = "Reviews a pull request with Qwen Code CLI"
+description = "Reviews a pull request with Qwen Code"
 prompt = """
 ## Role
 

--- a/.github/commands/qwen-triage.toml
+++ b/.github/commands/qwen-triage.toml
@@ -1,4 +1,4 @@
-description = "Triages an issue with Qwen Code CLI"
+description = "Triages an issue with Qwen Code"
 prompt = """
 ## Role
 

--- a/.github/workflows/qwen-invoke.yml
+++ b/.github/workflows/qwen-invoke.yml
@@ -37,7 +37,7 @@ jobs:
           permission-issues: 'write'
           permission-pull-requests: 'write'
 
-      - name: 'Run Qwen Code CLI'
+      - name: 'Run Qwen Code'
         id: 'run_qwen'
         uses: 'QwenLM/qwen-code-action@v1' # ratchet:exclude
         env:

--- a/QWEN.md
+++ b/QWEN.md
@@ -1,6 +1,6 @@
 ## Guidelines for Developing this GitHub Action
 
-This project is a **composite GitHub Action** for Qwen Code CLI integration, designed to be reusable, efficient, and secure for other developers.
+This project is a **composite GitHub Action** for Qwen Code integration, designed to be reusable, efficient, and secure for other developers.
 
 Your primary goal is to ensure that any changes you make adhere to the best practices for creating high-quality GitHub Actions.
 
@@ -43,6 +43,6 @@ When asked to modify the action, you should:
 ### Qwen Code Specific Considerations
 
 * **Authentication:** This action uses OpenAI-compatible API authentication with DashScope (Alibaba Cloud).
-* **CLI Installation:** The action installs the Qwen Code CLI from npm (@qwen-code/qwen-code) or from GitHub.
+* **CLI Installation:** The action installs the Qwen Code from npm (@qwen-code/qwen-code) or from GitHub.
 * **Configuration:** Settings are stored in `.qwen/settings.json` and commands in `.qwen/commands/`.
 * **Interaction:** Users mention `@qwencoder` in issues/PRs to trigger the action.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-`qwen-code-action` is a GitHub Action that integrates [Qwen Code] into your development workflow via the [Qwen Code CLI]. It acts both as an autonomous agent for critical routine coding tasks, and an on-demand collaborator you can quickly delegate work to.
+`qwen-code-action` is a GitHub Action that integrates [Qwen Code] into your development workflow. It acts both as an autonomous agent for critical routine coding tasks, and an on-demand collaborator you can quickly delegate work to.
 
 Use it to perform GitHub pull request reviews, triage issues, perform code analysis and modification, and more using [Qwen Code] conversationally (e.g., `@qwencoder fix this issue`) directly inside your GitHub repositories.
 
@@ -19,7 +19,7 @@ Use it to perform GitHub pull request reviews, triage issues, perform code analy
     - [Qwen Code Dispatch](#qwen-code-dispatch)
     - [Issue Triage](#issue-triage)
     - [Pull Request Review](#pull-request-review)
-    - [Qwen Code CLI Assistant](#qwen-code-cli-assistant)
+    - [Qwen Code Assistant](#qwen-code-assistant)
   - [Configuration](#configuration)
     - [Inputs](#inputs)
     - [Outputs](#outputs)
@@ -36,15 +36,15 @@ Use it to perform GitHub pull request reviews, triage issues, perform code analy
 
 - **Automation**: Trigger workflows based on events (e.g. issue opening) or schedules (e.g. nightly).
 - **On-demand Collaboration**: Trigger workflows in issue and pull request
-  comments by mentioning the [Qwen Code CLI] (e.g., `@qwencoder /review`).
+  comments by mentioning the [Qwen Code] (e.g., `@qwencoder /review`).
 - **Extensible with Tools**: Leverage [Qwen Code] models' tool-calling capabilities to
   interact with other CLIs like the [GitHub CLI] (`gh`).
 - **Customizable**: Use a `QWEN.md` file in your repository to provide
-  project-specific instructions and context to [Qwen Code CLI].
+  project-specific instructions and context to [Qwen Code].
 
 ## Quick Start
 
-Get started with Qwen Code CLI in your repository in just a few minutes:
+Get started with Qwen Code in your repository in just a few minutes:
 
 ### 1. Get a Qwen API Key
 
@@ -63,7 +63,7 @@ Store your API key as a secret named `QWEN_API_KEY` in your repository:
 Add the following entries to your `.gitignore` file:
 
 ```gitignore
-# qwen-code-cli settings
+# qwen-code settings
 .qwen/
 
 # GitHub App credentials
@@ -76,13 +76,13 @@ You have two options to set up a workflow:
 
 **Option A: Use setup command (Recommended)**
 
-1. Start the Qwen Code CLI in your terminal:
+1. Start the Qwen Code in your terminal:
 
    ```shell
    qwen
    ```
 
-2. In Qwen Code CLI in your terminal, type:
+2. In Qwen Code in your terminal, type:
 
    ```
    /setup-github
@@ -119,7 +119,7 @@ This action provides several pre-built workflows for different use cases. Each w
 
 ### Qwen Code Dispatch
 
-This workflow acts as a central dispatcher for Qwen Code CLI, routing requests to
+This workflow acts as a central dispatcher for Qwen Code, routing requests to
 the appropriate workflow based on the triggering event and the command provided
 in the comment. For a detailed guide on how to set up the dispatch workflow, go
 to the
@@ -137,11 +137,11 @@ This action can be used to automatically review pull requests when they are
 opened. For a detailed guide on how to set up the pull request review system,
 go to the [GitHub PR Review workflow documentation](./examples/workflows/pr-review).
 
-### Qwen Code CLI Assistant
+### Qwen Code Assistant
 
 This type of action can be used to invoke a general-purpose, conversational Qwen Code
 AI assistant within the pull requests and issues to perform a wide range of
-tasks. For a detailed guide on how to set up the general-purpose Qwen Code CLI workflow,
+tasks. For a detailed guide on how to set up the general-purpose Qwen Code workflow,
 go to the [Qwen Code Assistant workflow documentation](./examples/workflows/qwen-assistant).
 
 ## Configuration
@@ -152,24 +152,24 @@ go to the [Qwen Code Assistant workflow documentation](./examples/workflows/qwen
 
 - <a name="__input_qwen_api_key"></a><a href="#user-content-__input_qwen_api_key"><code>qwen_api_key</code></a>: _(Optional)_ The API key for the Qwen API.
 
-- <a name="__input_qwen_cli_version"></a><a href="#user-content-__input_qwen_cli_version"><code>qwen_cli_version</code></a>: _(Optional, default: `latest`)_ The version of the Qwen Code CLI to install. Can be "latest", "preview", "nightly", a specific version number, or a git branch, tag, or commit. For more information, see [Qwen Code CLI releases](https://github.com/QwenLM/qwen-code-action/blob/main/docs/releases.md).
+- <a name="__input_qwen_version"></a><a href="#user-content-__input_qwen_version"><code>qwen_version</code></a>: _(Optional, default: `latest`)_ The version of the Qwen Code to install. Can be "latest", "preview", "nightly", a specific version number, or a git branch, tag, or commit. For more information, see [Qwen Code releases](https://github.com/QwenLM/qwen-code/releases).
 
 - <a name="__input_qwen_debug"></a><a href="#user-content-__input_qwen_debug"><code>qwen_debug</code></a>: _(Optional)_ Enable debug logging and output streaming.
 
 - <a name="__input_qwen_model"></a><a href="#user-content-__input_qwen_model"><code>qwen_model</code></a>: _(Optional)_ The model to use with Qwen Code.
 
-- <a name="__input_prompt"></a><a href="#user-content-__input_prompt"><code>prompt</code></a>: _(Optional, default: `You are a helpful assistant.`)_ A string passed to the Qwen Code CLI's [`--prompt` argument](https://github.com/QwenLM/qwen-code-action/blob/main/docs/cli/configuration.md#command-line-arguments).
+- <a name="__input_prompt"></a><a href="#user-content-__input_prompt"><code>prompt</code></a>: _(Optional, default: `You are a helpful assistant.`)_ A string passed to the Qwen Code's [`--prompt` argument](https://qwenlm.github.io/qwen-code-docs/en/users/features/headless/#direct-prompts).
 
 - <a name="__input_settings"></a><a href="#user-content-__input_settings"><code>settings</code></a>: _(Optional)_ A JSON string written to `.qwen/settings.json` to configure the CLI's _project_ settings.
-    For more details, see the documentation on [settings files](https://github.com/QwenLM/qwen-code-action/blob/main/docs/cli/configuration.md#settings-files).
+    For more details, see the documentation on [settings files](https://qwenlm.github.io/qwen-code-docs/en/users/configuration/settings/).
 
 - <a name="__input_use_qwen_code_assist"></a><a href="#user-content-__input_use_qwen_code_assist"><code>use_qwen_code_assist</code></a>: _(Optional, default: `false`)_ Whether to use Code Assist for Qwen Code model access instead of the default Qwen Code API key.
-    For more information, see the [Qwen Code CLI documentation](https://github.com/QwenLM/qwen-code-action/blob/main/docs/cli/authentication.md).
+    For more information, see the [Qwen Code documentation](https://qwenlm.github.io/qwen-code-docs/en/users/overview/).
 
 - <a name="__input_use_vertex_ai"></a><a href="#user-content-__input_use_vertex_ai"><code>use_vertex_ai</code></a>: _(Optional, default: `false`)_ Whether to use Vertex AI for Qwen Code model access instead of the default Qwen Code API key.
-    For more information, see the [Qwen Code CLI documentation](https://github.com/QwenLM/qwen-code-action/blob/main/docs/cli/authentication.md).
+    For more information, see the [Qwen Code documentation](https://qwenlm.github.io/qwen-code-docs/en/users/overview/).
 
-- <a name="__input_extensions"></a><a href="#user-content-__input_extensions"><code>extensions</code></a>: _(Optional)_ A list of Qwen Code CLI extensions to install.
+- <a name="__input_extensions"></a><a href="#user-content-__input_extensions"><code>extensions</code></a>: _(Optional)_ A list of Qwen Code extensions to install.
 
 - <a name="__input_upload_artifacts"></a><a href="#user-content-__input_upload_artifacts"><code>upload_artifacts</code></a>: _(Optional, default: `false`)_ Whether to upload artifacts to the github action.
 
@@ -183,9 +183,9 @@ go to the [Qwen Code Assistant workflow documentation](./examples/workflows/qwen
 
 <!-- BEGIN_AUTOGEN_OUTPUTS -->
 
-- <a name="__output_summary"></a><a href="#user-content-__output_summary"><code>summary</code></a>: The summarized output from the Qwen Code CLI execution.
+- <a name="__output_summary"></a><a href="#user-content-__output_summary"><code>summary</code></a>: The summarized output from the Qwen Code execution.
 
-- <a name="__output_error"></a><a href="#user-content-__output_error"><code>error</code></a>: The error output from the Qwen Code CLI execution, if any.
+- <a name="__output_error"></a><a href="#user-content-__output_error"><code>error</code></a>: The error output from the Qwen Code execution, if any.
 
 <!-- END_AUTOGEN_OUTPUTS -->
 
@@ -195,8 +195,8 @@ We recommend setting the following values as repository variables so they can be
 
 | Name                        | Description                                            | Type     | Required | When Required             |
 | --------------------------- | ------------------------------------------------------ | -------- | -------- | ------------------------- |
-| `DEBUG`                     | Enables debug logging for the Qwen Code CLI.              | Variable | No       | Never                     |
-| `QWEN_CLI_VERSION`        | Controls which version of the Qwen Code CLI is installed. | Variable | No       | Pinning the CLI version   |
+| `DEBUG`                     | Enables debug logging for the Qwen Code.              | Variable | No       | Never                     |
+| `QWEN_CLI_VERSION`        | Controls which version of the Qwen Code is installed. | Variable | No       | Pinning the CLI version   |
 | `APP_ID`                    | GitHub App ID for custom authentication.               | Variable | No       | Using a custom GitHub App |
 
 To add a repository variable:
@@ -243,7 +243,7 @@ For detailed setup instructions for both Qwen and GitHub authentication, go to t
 
 ## Extensions
 
-The Qwen Code CLI can be extended with additional functionality through extensions.
+The Qwen Code can be extended with additional functionality through extensions.
 These extensions are installed from source from their GitHub repositories.
 
 For detailed instructions on how to set up and configure extensions, go to the
@@ -263,20 +263,19 @@ For a comprehensive guide on securing your repository and workflows, please refe
 ## Customization
 
 Create a [QWEN.md] file in the root of your repository to provide
-project-specific context and instructions to [Qwen Code CLI]. This is useful for defining
+project-specific context and instructions to [Qwen Code]. This is useful for defining
 coding conventions, architectural patterns, or other guidelines the model should
 follow for a given repository.
 
 ## Contributing
 
-Contributions are welcome! Check out the Qwen Code CLI
+Contributions are welcome! Check out the Qwen Code
 [**Contributing Guide**](./CONTRIBUTING.md) for more details on how to get
 started.
 
 [secrets]: https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions
 [Qwen Code]: https://github.com/QwenLM/qwen-code
 [DashScope]: https://dashscope.console.aliyun.com/apiKey
-[Qwen Code CLI]: https://github.com/QwenLM/qwen-code-action/
 [variables]: https://docs.github.com/en/actions/how-tos/write-workflows/choose-what-workflows-do/use-variables#creating-configuration-variables-for-a-repository
 [GitHub CLI]: https://docs.github.com/en/github-cli/github-cli
-[QWEN.md]: https://github.com/QwenLM/qwen-code-action/blob/main/docs/cli/configuration.md#context-files-hierarchical-instructional-context
+[QWEN.md]: https://qwenlm.github.io/qwen-code-docs/en/users/configuration/settings/#context-files-hierarchical-instructional-context

--- a/action.yml
+++ b/action.yml
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: 'Run Qwen Code CLI'
+name: 'Run Qwen Code'
 author: 'Alibaba Cloud'
 description: |-
-  Invoke the Qwen Code CLI from a GitHub Action.
+  Invoke the Qwen Code from a GitHub Action.
 
 inputs:
   openai_api_key:
@@ -30,7 +30,7 @@ inputs:
     required: false
     default: 'qwen-coder-plus-latest'
   qwen_cli_version:
-    description: 'The version of the Qwen Code CLI to install. Can be "latest", "preview", "nightly", a specific version number, or a git branch, tag, or commit.'
+    description: 'The version of the Qwen Code to install. Can be "latest", "preview", "nightly", a specific version number, or a git branch, tag, or commit.'
     required: false
     default: 'latest'
   qwen_debug:
@@ -38,7 +38,7 @@ inputs:
     required: false
   prompt:
     description: |-
-      A string passed to the Qwen Code CLI's `--prompt` argument.
+      A string passed to the Qwen Code's `--prompt` argument.
     required: false
     default: 'You are a helpful assistant.'
   settings:
@@ -46,14 +46,14 @@ inputs:
       A JSON string written to `.qwen/settings.json` to configure the CLI's _project_ settings.
     required: false
   extensions:
-    description: 'A list of Qwen Code CLI extensions to install.'
+    description: 'A list of Qwen Code extensions to install.'
     required: false
   upload_artifacts:
     description: 'Whether to upload artifacts to the github action.'
     required: false
     default: 'false'
   use_pnpm:
-    description: 'Whether or not to use pnpm instead of npm to install qwen-cli'
+    description: 'Whether or not to use pnpm instead of npm to install qwen-code'
     required: false
     default: 'false'
   workflow_name:
@@ -63,10 +63,10 @@ inputs:
 
 outputs:
   summary:
-    description: 'The summarized output from the Qwen Code CLI execution.'
+    description: 'The summarized output from the Qwen Code execution.'
     value: '${{ steps.qwen_run.outputs.qwen_response }}'
   error:
-    description: 'The error output from the Qwen Code CLI execution, if any.'
+    description: 'The error output from the Qwen Code execution, if any.'
     value: '${{ steps.qwen_run.outputs.qwen_errors }}'
 
 runs:
@@ -108,7 +108,7 @@ runs:
       env:
         WORKFLOW_NAME: '${{ inputs.workflow_name }}'
 
-    - name: 'Configure Qwen Code CLI'
+    - name: 'Configure Qwen Code'
       if: |-
         ${{ inputs.settings != '' }}
       run: |-
@@ -134,7 +134,7 @@ runs:
       with:
         version: 10
 
-    - name: 'Install Qwen Code CLI'
+    - name: 'Install Qwen Code'
       id: 'install'
       env:
         QWEN_CLI_VERSION: '${{ inputs.qwen_cli_version }}'
@@ -147,16 +147,16 @@ runs:
         VERSION_INPUT="${QWEN_CLI_VERSION:-latest}"
 
         if [[ "${VERSION_INPUT}" == "latest" || "${VERSION_INPUT}" == "preview" || "${VERSION_INPUT}" == "nightly" || "${VERSION_INPUT}" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9\.-]+)?(\+[a-zA-Z0-9\.-]+)?$ ]]; then
-          echo "Installing Qwen Code CLI from npm: @qwen-code/qwen-code@${VERSION_INPUT}"
+          echo "Installing Qwen Code from npm: @qwen-code/qwen-code@${VERSION_INPUT}"
           if [[ "${USE_PNPM}" == "true" ]]; then
             pnpm add --silent --global @qwen-code/qwen-code@"${VERSION_INPUT}"
           else
             npm install --silent --no-audit --prefer-offline --global @qwen-code/qwen-code@"${VERSION_INPUT}"
           fi
         else
-          echo "Installing Qwen Code CLI from GitHub: github:QwenLM/qwen-code-cli#${VERSION_INPUT}"
-          git clone https://github.com/QwenLM/qwen-code-cli.git
-          cd qwen-code-cli
+          echo "Installing Qwen Code from GitHub: github:QwenLM/qwen-code#${VERSION_INPUT}"
+          git clone https://github.com/QwenLM/qwen-code.git
+          cd qwen-code
           git checkout "${VERSION_INPUT}"
           npm install
           npm run bundle
@@ -164,13 +164,13 @@ runs:
         fi
         echo "Verifying installation:"
         if command -v qwen >/dev/null 2>&1; then
-          qwen --version || echo "Qwen Code CLI installed successfully (version command not available)"
+          qwen --version || echo "Qwen Code installed successfully (version command not available)"
         else
-          echo "Error: Qwen Code CLI not found in PATH"
+          echo "Error: Qwen Code not found in PATH"
           exit 1
         fi
         if [[ -n "${EXTENSIONS}" ]]; then
-          echo "Installing Qwen Code CLI extensions:"
+          echo "Installing Qwen Code extensions:"
           echo "${EXTENSIONS}" | jq -r '.[]' | while IFS= read -r extension; do
             extension=$(echo "${extension}" | xargs)
             if [[ -n "${extension}" ]]; then
@@ -180,7 +180,7 @@ runs:
           done
         fi
 
-    - name: 'Run Qwen Code CLI'
+    - name: 'Run Qwen Code'
       id: 'qwen_run'
       shell: 'bash'
       run: |-
@@ -198,9 +198,9 @@ runs:
         # Keep track of whether we've failed
         FAILED=false
 
-        # Run Qwen Code CLI with the provided prompt, using JSON output format
+        # Run Qwen Code with the provided prompt, using JSON output format
         if [[ "${DEBUG}" = true ]]; then
-          echo "::warning::Qwen Code CLI debug logging is enabled. This will stream responses, which could reveal sensitive information if processed with untrusted inputs."
+          echo "::warning::Qwen Code debug logging is enabled. This will stream responses, which could reveal sensitive information if processed with untrusted inputs."
         fi
 
         # We capture stdout (JSON) to TEMP_STDOUT and stderr to TEMP_STDERR
@@ -209,9 +209,9 @@ runs:
         fi
 
         if [[ "${DEBUG}" = true ]]; then
-          echo "::: Start Qwen Code CLI STDOUT :::"
+          echo "::: Start Qwen Code STDOUT :::"
           cat "${TEMP_STDOUT}"
-          echo "::: End Qwen Code CLI STDOUT :::"
+          echo "::: End Qwen Code STDOUT :::"
         fi
 
         # Create the artifacts directory and copy full logs
@@ -226,7 +226,7 @@ runs:
         fi
 
         # Parse JSON output to extract response and errors
-        # The Qwen CLI outputs an array of event objects, extract assistant message content
+        # The Qwen Code outputs an array of event objects, extract assistant message content
         RESPONSE=""
         ERROR_JSON=""
         if jq -e . "${TEMP_STDOUT}" >/dev/null 2>&1; then
@@ -238,10 +238,10 @@ runs:
            ERROR_JSON=$(jq -c '.error // empty' "${TEMP_STDERR}")
         fi
         if ! jq -e . "${TEMP_STDOUT}" >/dev/null 2>&1; then
-          echo "::warning::Qwen Code CLI stdout was not valid JSON"
+          echo "::warning::Qwen Code stdout was not valid JSON"
         fi
         if [[ -s "${TEMP_STDERR}" ]] && ! jq -e . "${TEMP_STDERR}" >/dev/null 2>&1; then
-          echo "::warning::Qwen Code CLI stderr was not empty but not valid JSON"
+          echo "::warning::Qwen Code stderr was not empty but not valid JSON"
         fi
 
 
@@ -267,11 +267,11 @@ runs:
           # If we have a structured error from JSON, use it for the error message
           if [[ -n "${ERROR_JSON}" ]]; then
              ERROR_MSG=$(jq -r '.message // .' <<< "${ERROR_JSON}")
-             echo "::error title=Qwen Code CLI execution failed::${ERROR_MSG}"
+             echo "::error title=Qwen Code execution failed::${ERROR_MSG}"
           fi
-          echo "::: Start Qwen Code CLI STDERR :::"
+          echo "::: Start Qwen Code STDERR :::"
           cat "${TEMP_STDERR}"
-          echo "::: End Qwen Code CLI STDERR :::"
+          echo "::: End Qwen Code STDERR :::"
           exit 1
         fi
       env:
@@ -283,7 +283,7 @@ runs:
         PROMPT: '${{ inputs.prompt }}'
         GH_WORKFLOW_NAME: '${{ steps.sanitize_workflow_name.outputs.gh_workflow_name }}'
 
-    - name: 'Upload Qwen Code CLI outputs'
+    - name: 'Upload Qwen Code outputs'
       if: |-
         ${{ inputs.upload_artifacts == 'true' }}
       uses: 'actions/upload-artifact@v4' # ratchet:exclude

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -1,6 +1,6 @@
 # Authentication
 
-This guide covers how to authenticate the Qwen Code CLI action in your GitHub Actions workflows.
+This guide covers how to authenticate the Qwen Code action in your GitHub Actions workflows.
 
 - [Authentication](#authentication)
   - [Qwen Code API Authentication](#qwen-code-api-authentication)
@@ -8,13 +8,13 @@ This guide covers how to authenticate the Qwen Code CLI action in your GitHub Ac
     - [Setup](#setup)
     - [Example](#example)
   - [GitHub Authentication](#github-authentication)
-    - [Method 1: Using the Default GITHUB_TOKEN](#method-1-using-the-default-github_token)
+    - [Method 1: Using the Default GITHUB\_TOKEN](#method-1-using-the-default-github_token)
     - [Method 2: Using a GitHub App (Recommended)](#method-2-using-a-github-app-recommended)
   - [Additional Resources](#additional-resources)
 
 ## Qwen Code API Authentication
 
-The Qwen Code CLI Action uses OpenAI-compatible API authentication through Alibaba Cloud's DashScope platform.
+The Qwen Code Action uses OpenAI-compatible API authentication through Alibaba Cloud's DashScope platform.
 
 ### Prerequisites
 
@@ -75,5 +75,4 @@ For details, see the [GitHub documentation](https://docs.github.com/en/apps/shar
 ## Additional Resources
 
 - [DashScope Documentation](https://help.aliyun.com/zh/dashscope/)
-- [Qwen Code CLI](https://github.com/QwenLM/qwen-code-cli)
 - [GitHub Actions Security](https://docs.github.com/en/actions/security-guides)

--- a/examples/workflows/CONFIGURATION.md
+++ b/examples/workflows/CONFIGURATION.md
@@ -18,7 +18,7 @@ This guide covers how to customize and configure Qwen Code workflows to meet you
 
 Qwen Code workflows are highly configurable. You can adjust their behavior by editing the corresponding `.yml` files in your repository.
 
-Qwen Code supports many settings that control how it operates. For a complete list, see the [Qwen Code documentation](https://github.com/QwenLM/qwen-code/blob/main/docs/cli/configuration.md#available-settings-in-settingsjson).
+Qwen Code supports many settings that control how it operates. For a complete list, see the [Qwen Code documentation](https://qwenlm.github.io/qwen-code-docs/en/users/configuration/settings/).
 
 ### Custom Commands (TOML Files)
 

--- a/examples/workflows/issue-triage/qwen-triage.toml
+++ b/examples/workflows/issue-triage/qwen-triage.toml
@@ -1,4 +1,4 @@
-description = "Triages an issue with Qwen Code CLI"
+description = "Triages an issue with Qwen Code"
 prompt = """
 ## Role
 

--- a/examples/workflows/pr-review/qwen-review.toml
+++ b/examples/workflows/pr-review/qwen-review.toml
@@ -1,4 +1,4 @@
-description = "Reviews a pull request with Qwen Code CLI"
+description = "Reviews a pull request with Qwen Code"
 prompt = """
 ## Role
 

--- a/examples/workflows/qwen-assistant/README.md
+++ b/examples/workflows/qwen-assistant/README.md
@@ -52,7 +52,7 @@ gha-creds-*.json
 
 To use this workflow, you can utilize either of the following methods:
 
-1. Run the `/setup-github` command in Qwen Code CLI on your terminal to set up workflows for your repository.
+1. Run the `/setup-github` command in Qwen Code on your terminal to set up workflows for your repository.
 2. Copy the workflow files into your repository's `.github/workflows` directory:
 
 ```bash
@@ -152,13 +152,13 @@ The Qwen Code assistant prompt is defined in the `qwen-invoke.toml` file. The ac
   curl -o .qwen/commands/qwen-invoke.toml https://raw.githubusercontent.com/QwenLM/qwen-code-action/main/examples/workflows/qwen-assistant/qwen-invoke.toml
   ```
 
-2. Edit `.qwen/commands/qwen-invoke.toml` to customize:
+1. Edit `.qwen/commands/qwen-invoke.toml` to customize:
    - Change its persona or primary function
    - Add project-specific guidelines or context
    - Instruct it to format its output in a specific way
    - Modify security constraints or workflow steps
 
-3. Commit the file to your repository:
+2. Commit the file to your repository:
 
   ```bash
   git add .qwen/commands/qwen-invoke.toml

--- a/examples/workflows/qwen-assistant/qwen-invoke.yml
+++ b/examples/workflows/qwen-assistant/qwen-invoke.yml
@@ -37,7 +37,7 @@ jobs:
           permission-issues: 'write'
           permission-pull-requests: 'write'
 
-      - name: 'Run Qwen Code CLI'
+      - name: 'Run Qwen Code'
         id: 'run_qwen'
         uses: 'QwenLM/qwen-code-action@v1' # ratchet:exclude
         env:

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "qwen-code-action",
   "version": "0.1.0",
-  "description": "GitHub Action for Qwen Code CLI integration",
+  "description": "GitHub Action for Qwen Code integration",
   "scripts": {
     "build": "echo \"No build required for composite action\"",
     "docs": "./node_modules/.bin/actions-gen-readme",


### PR DESCRIPTION
This PR updates documentation and descriptions to remove "CLI" references for better clarity regarding Qwen Code integration.